### PR TITLE
Fix IndexData feature offsets to account for size prefix

### DIFF
--- a/flatgeobuf/file_writer.go
+++ b/flatgeobuf/file_writer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gogama/flatgeobuf/flatgeobuf/flat"
 	"github.com/gogama/flatgeobuf/packedrtree"
+	flatbuffers "github.com/google/flatbuffers/go"
 )
 
 // FileWriter writes a FlatGeobuf file to an underlying stream.
@@ -178,7 +179,7 @@ func (w *FileWriter) IndexData(p []flat.Feature) (n int, err error) {
 				return wrapErr("feature %d", err, i)
 			}
 			bounds.Expand(&refs[i].Box)
-			offset += int64(size)
+			offset += int64(size) + flatbuffers.SizeUint32
 		}
 		return nil
 	})

--- a/flatgeobuf/file_writer_test.go
+++ b/flatgeobuf/file_writer_test.go
@@ -730,7 +730,7 @@ func TestFileWriter_IndexData(t *testing.T) {
 					RefIndex: 1,
 				},
 				{
-					Offset:   76,
+					Offset:   80,
 					RefIndex: 0,
 				},
 			}, sr)


### PR DESCRIPTION
## Summary
Fix `FileWriter.IndexData` feature offsets in the packed Hilbert R-tree index. 

`IndexData` previously advanced each feature offset by only the FlatBuffer table size. On disk, each feature is already written as `[uint32 size prefix][table bytes]`, so indexed offsets after the first feature were short by 4 bytes per preceding feature.

This now adds `flatbuffers.SizeUint32` to the per-feature offset increment. That matches the writer’s size-prefixed data layout and the reader’s existing offset accounting, which is compliant with the FlatGeobuf spec.

## Impact
Files written with `FileWriter.IndexData` now have spec-compliant index offsets. Previously, sequential reads worked, but indexed seeks jumped to the wrong byte and fail in conforming readers, including other FlatGeobuf implementations.

Files produced by prior versions may still have bad index offsets, but this does not introduce a new compatibility issue since indexed seeks on those files were already broken for datasets with more than one feature. This change fixes the writer going forward and we didn't touch the reader.

## Tests
Updated `TestFileWriter_IndexData/Success/Search` to expect the proper offset `80` instead of the buggy `76`, reflecting the first feature’s serialized size including its 4-byte prefix.

## Verification
  - `go build ./...`
  - `go test ./...`
  - `go vet ./...`